### PR TITLE
assert_same_elements optimization

### DIFF
--- a/lib/shoulda/context/assertions.rb
+++ b/lib/shoulda/context/assertions.rb
@@ -9,8 +9,8 @@ module Shoulda # :nodoc:
           [a1, a2].each {|a| assert_respond_to(a, m, "Are you sure that #{a.inspect} is an array?  It doesn't respond to #{m}.") }
         end
 
-        assert a1h = a1.inject({}) { |h,e| h[e] = a1.select { |i| i == e }.size; h }
-        assert a2h = a2.inject({}) { |h,e| h[e] = a2.select { |i| i == e }.size; h }
+        assert a1h = a1.inject({}) { |h,e| h[e] ||= a1.select { |i| i == e }.size; h }
+        assert a2h = a2.inject({}) { |h,e| h[e] ||= a2.select { |i| i == e }.size; h }
 
         assert_equal(a1h, a2h, msg)
       end

--- a/test/shoulda/helpers_test.rb
+++ b/test/shoulda/helpers_test.rb
@@ -26,9 +26,16 @@ class HelpersTest < Test::Unit::TestCase # :nodoc:
       assert_raises(Test::Unit::AssertionFailedError) do
         assert_same_elements(@a, [3, 3, "def", "abc"])
       end
+      assert_same_elements([@a, "abc"].flatten, ["abc", 3, "def", "abc"])
       assert_raises(Test::Unit::AssertionFailedError) do
         assert_same_elements([@a, "abc"].flatten, [3, 3, "def", "abc"])
       end
+    end
+
+    should "only count the number of occurrences once for each unique value" do
+      a1 = [@a, "abc"].flatten
+      a1.expects(:select).times(3).returns(["abc", "abc"], ["def"], [3])
+      assert_same_elements(a1, ["abc", 3, "def", "abc"])
     end
   end
 


### PR DESCRIPTION
For arrays that have duplicate elements, assert_same_elements counts how many times that element occurs in the array multiple times. I made a branch that prevents that re-work
https://github.com/misfo/shoulda-context/tree/assert_same_elements-optimization

Also, this branch will walk your dog and give your grandma high fives
