### PR TITLE
assert_reject should favor :does_not_match? on the matcher if it exists

### DIFF
--- a/lib/shoulda/context/assertions.rb
+++ b/lib/shoulda/context/assertions.rb
@@ -61,13 +61,16 @@ module Shoulda # :nodoc:
         end
       end
 
-      # Asserts that the given matcher returns false when +target+ is passed to #matches?
+      # Asserts that the given matcher returns true when +target+ is passed to #does_not_match?
+      # or false when +target+ is passed to #matches? if #does_not_match? is not implemented
       def assert_rejects(matcher, target, options = {})
         if matcher.respond_to?(:in_context)
           matcher.in_context(self)
         end
 
-        unless matcher.matches?(target)
+        not_match = matcher.respond_to?(:does_not_match?) ? matcher.does_not_match?(target) : !matcher.matches?(target)
+
+        if not_match
           assert_block { true }
           if options[:message]
             assert_match options[:message], matcher.failure_message

--- a/test/shoulda/helpers_test.rb
+++ b/test/shoulda/helpers_test.rb
@@ -61,19 +61,36 @@ class HelpersTest < Test::Unit::TestCase # :nodoc:
     end
 
     context "when given to assert_rejects" do
-      setup do
-        begin
-          assert_rejects @matcher, 'target'
-        rescue Test::Unit::AssertionFailedError => @error
+      context "and matcher has :does_not_match?" do
+        setup do
+          begin
+            @matcher.stubs(:matches?).returns(false)
+            @matcher.stubs(:does_not_match?).returns(true)
+            assert_rejects @matcher, 'target'
+          rescue Test::Unit::AssertionFailedError => @error
+          end
+        end
+
+        should "pass" do
+          assert_nil @error
         end
       end
 
-      should "fail" do
-        assert_not_nil @error
-      end
+      context "and matcher does not have :does_not_match?" do
+        setup do
+          begin
+            assert_rejects @matcher, 'target'
+          rescue Test::Unit::AssertionFailedError => @error
+          end
+        end
 
-      should "use the error message from the matcher" do
-        assert_equal 'big time failure', @error.message
+        should "fail" do
+          assert_not_nil @error
+        end
+
+        should "use the error message from the matcher" do
+          assert_equal 'big time failure', @error.message
+        end
       end
     end
   end


### PR DESCRIPTION
RSpec matchers have a negative matcher method called `does_not_match?` which can be used to test for match failure instead of `match?` (in case more complex match failure needs to be done than simply `!matches?(subject)`)

`assert_reject` should favor using this method if it exists on the matcher.

reference: https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/expectations/handler.rb#L32-35
