### PR TITLE
should require 'test/unit/testcase' and not 'test/unit'

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'test/unit/testcase'
 require 'shoulda/context/version'
 require 'shoulda/context/proc_extensions'
 require 'shoulda/context/assertions'


### PR DESCRIPTION
This is because requiring 'test/unit' triggers Test::Unit's autorun functionality, which can lead to errors, as shown in this Gist: https://gist.github.com/1402816.

The problem surfaced in Spree 0.70.0's test suite as well as in Rubygems.org test suite.

By requiring `test/unit/testcase` instead, it will not trigger this autorun event.
