### PR TITLE
Only require test/unit if it isn't defined

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -1,4 +1,7 @@
-require 'test/unit'
+if !defined?(Test::Unit::TestCase)
+  require 'test/unit'
+end
+
 require 'shoulda/context/version'
 require 'shoulda/context/proc_extensions'
 require 'shoulda/context/assertions'


### PR DESCRIPTION
This fixes the issue people have had with minitest and rake breaking.
