### PR TITLE
Add Rails 4 support.

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -1,6 +1,18 @@
-if !defined?(Test::Unit::TestCase)
-  require 'test/unit/testcase'
+begin
+  # if present, then also loads MiniTest::Spec
+  ActiveSupport::TestCase
+rescue
 end
+
+if defined?([ActiveSupport::TestCase, MiniTest::Spec]) && (ActiveSupport::TestCase.ancestors.include?(MiniTest::Spec))
+  base_test_case = MiniTest::Spec
+else
+  if !defined?(Test::Unit::TestCase)
+    require 'test/unit/testcase'
+  end
+  base_test_case = Test::Unit::TestCase
+end
+
 
 require 'shoulda/context/version'
 require 'shoulda/context/proc_extensions'
@@ -8,8 +20,15 @@ require 'shoulda/context/assertions'
 require 'shoulda/context/context'
 require 'shoulda/context/autoload_macros'
 
-class Test::Unit::TestCase
-  include Shoulda::Context::Assertions
-  include Shoulda::Context::InstanceMethods
-  extend Shoulda::Context::ClassMethods
+
+module ShouldaContextLoadable
+  def self.included(base)
+    base.class_eval do
+      include Shoulda::Context::Assertions
+      include Shoulda::Context::InstanceMethods
+    end
+    base.extend(Shoulda::Context::ClassMethods)
+  end
 end
+
+base_test_case.class_eval { include ShouldaContextLoadable }


### PR DESCRIPTION
Mix shoulda-context in MiniTest::Spec if present and part of ActiveSupport::TestCase's ancestors.

This is a simple suggestion for adding support to upcoming Rails 4, which now has its base test class inheriting from MiniTest::Spec instead of Test::Unit::TestCase.

I'm not expecting this pull-request to merged right away, as it doesn't include any tests or Appraisal support for Rails 4, but I'd love to hear your thoughts on this approach.
