### PR TITLE
Support for Rails 4 RC1

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -1,11 +1,11 @@
 begin
-  # if present, then also loads MiniTest::Spec
+  # if present, then also loads MiniTest::Unit::TestCase
   ActiveSupport::TestCase
 rescue
 end
 
-if defined?([ActiveSupport::TestCase, MiniTest::Spec]) && (ActiveSupport::TestCase.ancestors.include?(MiniTest::Spec))
-  base_test_case = MiniTest::Spec
+if defined?([ActiveSupport::TestCase, MiniTest::Unit::TestCase]) && (ActiveSupport::TestCase.ancestors.include?(MiniTest::Unit::TestCase))
+  base_test_case = MiniTest::Unit::TestCase
 else
   if !defined?(Test::Unit::TestCase)
     require 'test/unit/testcase'


### PR DESCRIPTION
This is a minor change to the code introduced in https://github.com/thoughtbot/shoulda-context/pull/19 to update to the current Rails RC1 release in which ActiveSupport::TestCase now inherits from MiniTest::Unit::TestCase instead of MiniTest::Spec.

For the change in Rails, please see: https://github.com/rails/rails/commit/eb4930e3c724cf71d6ce5bb2aec4af82b2025b03

I'm not sure if you would want to also include support for the beta Rails version, but my assumption was that people will be upgrading away from that quickly, and you wouldn't want any old code related to that hanging around.
