### PR TITLE
Handle deprecation of assert_block safely

### DIFF
--- a/lib/shoulda/context/assertions.rb
+++ b/lib/shoulda/context/assertions.rb
@@ -52,14 +52,14 @@ module Shoulda # :nodoc:
         end
 
         if matcher.matches?(target)
-          assert_block { true }
+          safe_assert_block { true }
           if options[:message]
             message = matcher.respond_to?(:failure_message_for_should_not) ? matcher.failure_message_for_should_not : matcher.negative_failure_message
             assert_match options[:message], message
           end
         else
           message = matcher.respond_to?(:failure_message_for_should) ? matcher.failure_message_for_should : matcher.failure_message
-          assert_block(message) { false }
+          safe_assert_block(message) { false }
         end
       end
 
@@ -73,14 +73,22 @@ module Shoulda # :nodoc:
         not_match = matcher.respond_to?(:does_not_match?) ? matcher.does_not_match?(target) : !matcher.matches?(target)
 
         if not_match
-          assert_block { true }
+          safe_assert_block { true }
           if options[:message]
             message = matcher.respond_to?(:failure_message_for_should) ? matcher.failure_message_for_should : matcher.failure_message
             assert_match options[:message], message
           end
         else
           message = matcher.respond_to?(:failure_message_for_should_not) ? matcher.failure_message_for_should_not : matcher.negative_failure_message
-          assert_block(message) { false }
+          safe_assert_block(message) { false }
+        end
+      end
+
+      def safe_assert_block(message = nil, &block)
+        if respond_to?(:assert_block)
+          assert_block message, &block
+        else
+          assert yield, message
         end
       end
     end


### PR DESCRIPTION
MiniTest 4.6.0 and higher no longer has assert_block as a method [opting for assert(yield, message)] https://github.com/seattlerb/minitest/blob/master/History.txt#L134-L140

This enables users with older MiniTest to still use assert_block if it's there and the newer format if it's not.

Not sure how to write a test for this as it is a dependency-based issue. 
