### PR TITLE
Fatal exception under JRuby: uninitialized constant ActiveSupport

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -1,25 +1,24 @@
 begin
-  # if present, then also loads MiniTest::Unit::TestCase
+  # if present, load and set base_test_case
   ActiveSupport::TestCase
+  if defined?([ActiveSupport::TestCase, MiniTest::Unit::TestCase]) &&
+     (ActiveSupport::TestCase.ancestors.include?(MiniTest::Unit::TestCase))
+    base_test_case = MiniTest::Unit::TestCase
+  end
 rescue
 end
 
-if defined?([ActiveSupport::TestCase, MiniTest::Unit::TestCase]) && (ActiveSupport::TestCase.ancestors.include?(MiniTest::Unit::TestCase))
-  base_test_case = MiniTest::Unit::TestCase
-else
-  if !defined?(Test::Unit::TestCase)
-    require 'test/unit/testcase'
-  end
+# no base_test_case set, using Test:Unit:TestCase
+unless base_test_case
+  require 'test/unit/testcase' unless defined?(Test::Unit::TestCase)
   base_test_case = Test::Unit::TestCase
 end
-
 
 require 'shoulda/context/version'
 require 'shoulda/context/proc_extensions'
 require 'shoulda/context/assertions'
 require 'shoulda/context/context'
 require 'shoulda/context/autoload_macros'
-
 
 module ShouldaContextLoadable
   def self.included(base)


### PR DESCRIPTION
The dependency chain for 3.5.0 under JRuby combined with how active support was being required and used here was causing some issues and completely breaks shoulda under JRuby 1.7.x. Simply requiring shoulda or shoulda-context on the JRuby platform results in a fatal exception.

Steps to reproduce:

``` ruby
rvm use jruby
gem install shoulda
ruby -e "require 'shoulda'"
```

Result:

```
NameError: uninitialized constant ActiveSupport
  const_missing at org/jruby/RubyModule.java:2631
         (root) at /Users/brandon/.rvm/gems/jruby-1.7.4@sandbox/gems/shoulda-context-1.1.2/lib/shoulda/context.rb:7
        require at org/jruby/RubyKernel.java:1054
        require at /Users/brandon/.rvm/rubies/jruby-1.7.4/lib/ruby/shared/rubygems/custom_require.rb:36
         (root) at /Users/brandon/.rvm/gems/jruby-1.7.4@sandbox/gems/shoulda-3.5.0/lib/shoulda.rb:3
        require at org/jruby/RubyKernel.java:1054
        require at /Users/brandon/.rvm/rubies/jruby-1.7.4/lib/ruby/shared/rubygems/custom_require.rb:60
         (root) at -e:1
```

This pull request resolves the issue and all tests pass successfully under:
- MRI 1.9.3
- MRI 2.0.0
- JRuby 1.7.4
