### PR TITLE
Fix safe_assert_block message argument

### DIFF
--- a/lib/shoulda/context/assertions.rb
+++ b/lib/shoulda/context/assertions.rb
@@ -84,7 +84,7 @@ module Shoulda # :nodoc:
         end
       end
 
-      def safe_assert_block(message = nil, &block)
+      def safe_assert_block(message = "assert_block failed.", &block)
         if respond_to?(:assert_block)
           assert_block message, &block
         else


### PR DESCRIPTION
### WHAT

Add a default message to `safe_assert_block`.
### WHY

You can recreate this bug in the console of a fresh Rails 3.2 app with `gem 'shoulda-context', '1.1.3'`:

``` ruby
require 'test/unit'
require 'shoulda'
include Test::Unit::Assertions
include Shoulda::Context::Assertions
safe_assert_block { true }
```

which raises this:

``` ruby
ArgumentError: assertion message must be String or Proc, but NilClass was given.
    from /.../lib/ruby/1.9.1/test/unit/assertions.rb:52:in `assert_block'
    from /.../gems/shoulda-context-1.1.3/lib/shoulda/context/assertions.rb:89:in `safe_assert_block'
...
```

So when using `safe_assert_block` without a `message` parameter (such as in `assert_accepts`/`assert_rejects`), you run into this error. 

This is because `shoulda-context` uses the `test-unit` gem as a [development dependency](https://github.com/thoughtbot/shoulda-context/blob/7c02ea0676a98371cfd8a8d594e7aa06b39eedfc/shoulda-context.gemspec#L26), which adds its own `assert_block` assertion with a default message (vs no default message in the `test/unit` version that most people use).

The real problem I think is the use of the `test-unit` gem because running tests on `shoulda-context` wouldn't catch this case, although there might be a good reason for it so I just went with a simple solution.
