### PR TITLE
Rails 4 doesn't load rails/init.rb

### DIFF
--- a/lib/shoulda-context.rb
+++ b/lib/shoulda-context.rb
@@ -1,1 +1,3 @@
 require "shoulda/context"
+
+require "shoulda/railtie" if defined?(Rails)

--- a/lib/shoulda-context.rb
+++ b/lib/shoulda-context.rb
@@ -1,3 +1,1 @@
 require "shoulda/context"
-
-require "shoulda/railtie" if defined?(Rails)

--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -31,3 +31,5 @@ module ShouldaContextLoadable
 end
 
 base_test_case.class_eval { include ShouldaContextLoadable }
+
+require "shoulda/railtie" if defined?(Rails)

--- a/lib/shoulda/railtie.rb
+++ b/lib/shoulda/railtie.rb
@@ -1,0 +1,9 @@
+module Shoulda
+  class Railtie < Rails::Railtie
+    initializer "Shoulda.autoload_macros" do
+      if Rails.env.test?
+        Shoulda.autoload_macros Rails.root, File.join("vendor", "{plugins,gems}", "*")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails 4 seems to have dropped support for rails/init.rb as a way of initialising gems. As a result shoulda-context no longer automatically loads macros from test/shoulda_macros.

The quick workaround is to add

```
Shoulda.autoload_macros(Rails.root)
```

in your test/test_helper.rb

The better solution would be to add support for Rails' Railties extension mechanism, which seems to be the supported approach now.
