### PR TITLE
described_type: no ancestor lookup for constants that don't exist

### DIFF
--- a/lib/shoulda/context/context.rb
+++ b/lib/shoulda/context/context.rb
@@ -210,7 +210,9 @@ module Shoulda
         @described_type ||= self.name.
           gsub(/Test$/, '').
           split('::').
-          inject(Object) { |parent, local_name| parent.const_get(local_name) }
+          inject(Object) do |parent, local_name|
+            parent.const_get(local_name, false)
+          end
       end
 
       # Sets the return value of the subject instance method:

--- a/test/shoulda/context_test.rb
+++ b/test/shoulda/context_test.rb
@@ -172,10 +172,17 @@ class ::Some
   class NestedModel; end
 end
 
-
 class Some::NestedModelTest < Test::Unit::TestCase
   should "determine the described type for a nested model" do
     assert_equal Some::NestedModel, self.class.described_type
+  end
+end
+
+class Some::SomeTest < Test::Unit::TestCase
+  should "not fallback to higher-level constants with same name" do
+    assert_raises(NameError) do
+      assert_equal nil, self.class.described_type
+    end
   end
 end
 


### PR DESCRIPTION
### WHAT

When detecting the `described_type` of a context, don't let `const_get` lookup the target class on ancestors of a class if the target class doesn't exist under the explicit namespace. 

### WHY

It doesn't make sense to fallback to a class that doesn't match the test name. For instance:

``` ruby
class Horse; end

class Charlie::HorseTest < ActiveSupport::TestCase
  ...
end
```

If `Charlie::Horse` doesn't exist, the test should raise an error instead of using `Horse` instead.

Currently, when detecting the `described_type`,  `shoulda-context` will walk `['Object', 'Charlie', 'Horse']` and try to detect each constant from the previous one. But since it it uses `const_get` with the default `inherit=true` argument, it will:

* look for `Object::Charlie`
* look for `Object::Charlie::Horse`, which fails
* fallback to `Object::Horse`, which is a completely different constant

NB Rails also sets the `inherit=false` arg in [constantize](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/inflector/methods.rb#L275)

