### PR TITLE
Only replace 'Test' appearing at the end of a test class name

### DIFF
--- a/lib/shoulda/context/context.rb
+++ b/lib/shoulda/context/context.rb
@@ -73,7 +73,7 @@ module Shoulda
         if Shoulda::Context.current_context
           Shoulda::Context.current_context.should(name_or_matcher, options, &blk)
         else
-          context_name = self.name.gsub(/Test/, "") if self.name
+          context_name = self.name.gsub(/Test$/, "") if name
           context = Shoulda::Context::Context.new(context_name, self) do
             should(name_or_matcher, options, &blk)
           end
@@ -92,7 +92,7 @@ module Shoulda
         if Shoulda::Context.current_context
           Shoulda::Context.current_context.should_not(matcher)
         else
-          context_name = self.name.gsub(/Test/, "") if self.name
+          context_name = self.name.gsub(/Test$/, "") if name
           context = Shoulda::Context::Context.new(context_name, self) do
             should_not(matcher)
           end
@@ -132,7 +132,7 @@ module Shoulda
 
       # Just like should, but never runs, and instead prints an 'X' in the Test::Unit output.
       def should_eventually(name, options = {}, &blk)
-        context_name = self.name.gsub(/Test/, "")
+        context_name = self.name.gsub(/Test$/, "")
         context = Shoulda::Context::Context.new(context_name, self) do
           should_eventually(name, &blk)
         end

--- a/test/shoulda/should_test.rb
+++ b/test/shoulda/should_test.rb
@@ -289,3 +289,66 @@ class ShouldTest < Test::Unit::TestCase # :nodoc:
   end
 
 end
+
+class RedTestarossaDriver
+end
+
+class RedTestarossaDriverTest < Test::Unit::TestCase # :nodoc:
+  class DummyMatcher
+    def self.description
+      "fail to construct the proper test name with a 'should_not'"
+    end
+
+    def self.matches?(*)
+      false
+    end
+
+    def self.negative_failure_message
+      "dummy failure message"
+    end
+  end
+
+  setup do
+    # Testing should_eventually is a little tricky because the code inside the
+    # block doesn't actually get executed.  So instead, we'll check that the
+    # following line in Shoulda::Context.should_eventually gets called
+    # with the proper value for context_name:
+    # context = Shoulda::Context::Context.new(context_name, self) do ...
+    #
+    # Testing should_not is also a little difficult since it doesn't take a
+    # block, but we can check it the same way as for should_eventually, hence
+    # the 'twice' in the below expectation.
+    Shoulda::Context::Context.expects(:new).
+      twice.
+      with("RedTestarossaDriver", RedTestarossaDriverTest)
+  end
+
+  should "see the name of my class as RedTestarossaDriverTest" do
+    assert_equal "RedTestarossaDriverTest", self.class.name
+  end
+
+  should "properly construct the test name with a 'should'" do
+    test_name_regex = /^test: RedTestarossaDriver/
+    assert_match test_name_regex, to_s
+  end
+
+  begin
+    should_eventually(
+      "properly construct the test name with a 'should_eventually'",
+    )
+  rescue
+    # without this rescue, the expectation above causes an error to be thrown
+    # when running the test:
+    # context.rb:139:in `should_eventually':
+    # undefined method `build' for nil:NilClass (NoMethodError)
+  end
+
+  begin
+    should_not DummyMatcher
+  rescue
+    # without this rescue, the expectation above causes an error to be thrown
+    # when running the test:
+    # context.rb:99:in `should_not':
+    # undefined method `build' for nil:NilClass (NoMethodError)
+  end
+end


### PR DESCRIPTION
### Motivation

There are three methods defined in `Shoulda::Context::ClassMethods` where a `context_name` is produced by a context replacing all instances of `"Test"` in its own name with blank strings:

```
should
should_eventually
should_not
```

The intent seems to be to take a test class name like `UserEmailsTest` and reduce it to a context name like `UserEmails`.  However, if the class name happens to contain the substring `'Test'`, this results in probably unexpected behavior.  For example, `RedTestarossaDriverTest` becomes `RedarossaDriverTest`.
### Changes

This pull request introduces changes to only match/replace `"Test"` at the end of a string.  Incidentally, this is consistent with the approach taken in the `described_type` method defined in the same file:

```
context.rb#211:
gsub(/Test$/, '').
```
### Further Considerations

It could be reasonably argued that the intent is to replace instances of `"Test"` anywhere to allow for flexibility in naming conventions, e.g. `TestAllTheThings` => `AllTheThings`.  However, there's still a problem for classes whose names contain words like `Testarossa`, `Testosterone`, and `Testimonial`.

In that case, an alternate suggestion would be to use something like `.gsub(/Test([^a-z])/, $1.to_s).sub(/Test$/, '')`

However, this solution would also preclude names like `TestFrameworkDetectionTest` (one of the tests in the `shoulda-context` repo itself).
