### PR TITLE
Correct rerun snippet in Rails projects

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+rubocop:
+  version: 0.64.0
+  config_file: .rubocop.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    snowglobe (0.1.0)
+    snowglobe (0.3.0)
     test-unit (3.3.0)
       power_assert
     thor (0.20.3)
@@ -63,7 +63,7 @@ DEPENDENCIES
   rake
   rubocop (= 0.64.0)
   shoulda-context!
-  snowglobe
+  snowglobe (>= 0.3.0)
   test-unit
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,8 +22,8 @@ GEM
     minitest (5.11.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -33,15 +33,13 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    psych (3.1.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.65.0)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
@@ -63,7 +61,7 @@ DEPENDENCIES
   mocha
   pry-byebug
   rake
-  rubocop
+  rubocop (= 0.64.0)
   shoulda-context!
   snowglobe
   test-unit

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -123,7 +123,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    snowglobe (0.1.0)
+    snowglobe (0.3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -154,7 +154,7 @@ DEPENDENCIES
   rake
   rubocop (= 0.64.0)
   shoulda-context!
-  snowglobe
+  snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
 

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -74,8 +74,8 @@ GEM
       metaclass (~> 0.0.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -85,7 +85,6 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    psych (3.1.0)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -115,12 +114,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.65.0)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
@@ -154,7 +152,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 4.2.0)
   rake
-  rubocop
+  rubocop (= 0.64.0)
   shoulda-context!
   snowglobe
   sqlite3 (~> 1.3.6)

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -126,7 +126,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    snowglobe (0.1.0)
+    snowglobe (0.3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -160,7 +160,7 @@ DEPENDENCIES
   rake
   rubocop (= 0.64.0)
   shoulda-context!
-  snowglobe
+  snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
 

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -78,8 +78,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -89,7 +89,6 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    psych (3.1.0)
     rack (2.0.6)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -118,12 +117,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.65.0)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
@@ -160,7 +158,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.0.0)
   rake
-  rubocop
+  rubocop (= 0.64.0)
   shoulda-context!
   snowglobe
   sqlite3 (~> 1.3.6)

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -78,8 +78,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -89,7 +89,6 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    psych (3.1.0)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -118,12 +117,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.65.0)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
@@ -160,7 +158,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.1.0)
   rake
-  rubocop
+  rubocop (= 0.64.0)
   shoulda-context!
   snowglobe
   sqlite3 (~> 1.3.6)

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -126,7 +126,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    snowglobe (0.1.0)
+    snowglobe (0.3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -160,7 +160,7 @@ DEPENDENCIES
   rake
   rubocop (= 0.64.0)
   shoulda-context!
-  snowglobe
+  snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
 

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -134,7 +134,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    snowglobe (0.1.0)
+    snowglobe (0.3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -168,7 +168,7 @@ DEPENDENCIES
   rake
   rubocop (= 0.64.0)
   shoulda-context!
-  snowglobe
+  snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
 

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -85,8 +85,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -96,7 +96,6 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    psych (3.1.0)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -126,12 +125,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.65.0)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
@@ -168,7 +166,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.2.0)
   rake
-  rubocop
+  rubocop (= 0.64.0)
   shoulda-context!
   snowglobe
   sqlite3 (~> 1.3.6)

--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -9,6 +9,7 @@ require "shoulda/context/world"
 
 if defined?(Rails)
   require "shoulda/context/railtie"
+  require "shoulda/context/rails_test_unit_reporter_patch"
 end
 
 Shoulda::Context.configure do |config|

--- a/lib/shoulda/context/rails_test_unit_reporter_patch.rb
+++ b/lib/shoulda/context/rails_test_unit_reporter_patch.rb
@@ -1,0 +1,21 @@
+begin
+  require "rails/test_unit/reporter"
+
+  Rails::TestUnitReporter.class_eval do
+    # Fix #format_rerun_snippet so that it works with recent versions of Minitest.
+    # This was cribbed from:
+    # <https://github.com/rails/rails/commit/ff0d5f14504f1aa29ad908ab15bab66b101427b7#diff-a071a1c8f51ce3b8bcb17ca59c79fc70>
+    def format_rerun_snippet(result)
+      location, line =
+        if result.respond_to?(:source_location)
+          result.source_location
+        else
+          result.method(result.name).source_location
+        end
+
+      "#{executable} #{relative_path_for(location)}:#{line}"
+    end
+  end
+rescue LoadError
+  # Rails::TestUnitReporter was introduced in Rails 5
+end

--- a/shoulda-context.gemspec
+++ b/shoulda-context.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "0.64.0"
   s.add_development_dependency "snowglobe"
 end

--- a/shoulda-context.gemspec
+++ b/shoulda-context.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake"
   s.add_development_dependency "rubocop", "0.64.0"
-  s.add_development_dependency "snowglobe"
+  s.add_development_dependency "snowglobe", ">= 0.3.0"
 end

--- a/test/shoulda/railtie_test.rb
+++ b/test/shoulda/railtie_test.rb
@@ -33,7 +33,7 @@ class RailtieTest < PARENT_TEST_CASE
         end
       RUBY
 
-      app.run_command!("bundle exec rake test")
+      app.run_n_unit_test_suite
     end
   end
 

--- a/test/shoulda/rerun_snippet_test.rb
+++ b/test/shoulda/rerun_snippet_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class RerunSnippetTest < PARENT_TEST_CASE
+  context "A Rails application with shoulda-context added to it" do
+    should "display the correct rerun snippet when a test fails" do
+      if app.rails_version >= 5 && TEST_FRAMEWORK == "minitest"
+        app.create
+
+        app.write_file("test/models/failing_test.rb", <<~RUBY)
+          ENV["RAILS_ENV"] = "test"
+          require_relative "../../config/environment"
+
+          class FailingTest < #{PARENT_TEST_CASE}
+            should "fail" do
+              assert false
+            end
+          end
+        RUBY
+
+        command_runner = app.run_n_unit_test_suite
+
+        assert_includes(
+          command_runner.output,
+          "bin/rails test test/models/failing_test.rb:5"
+        )
+      end
+    end
+  end
+
+  def app
+    @_app ||= RailsApplicationWithShouldaContext.new
+  end
+end


### PR DESCRIPTION
This partially reverts commit 9b791b4f26e49930f59a49c5b2acff67aabcc15f,
and then fixes the use of `context` so that it doesn't generate a
warning.

In addition to fixing the rerun snippet, in writing tests, a
compatibility with Rails::TestUnitReporter was revealed and this was
also fixed as well.

---

Fixes #56.