### PR TITLE
Remove 'assigned but unused variable' warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem "minitest"
 gem "test-unit"
+gem "warnings_logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       power_assert
     thor (0.20.3)
     unicode-display_width (1.4.1)
+    warnings_logger (0.1.0)
 
 PLATFORMS
   ruby
@@ -65,6 +66,7 @@ DEPENDENCIES
   shoulda-context!
   snowglobe (>= 0.3.0)
   test-unit
+  warnings_logger
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.ruby_opts += ["-w"]
   t.pattern = "test/**/*_test.rb"
-  t.verbose = false
+  t.verbose = true
 end
 
 task :default do

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest"
 gem "test-unit"
+gem "warnings_logger"
 gem "sqlite3", "~> 1.3.6"
 gem "rails", "~> 4.2.0"
 

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -139,6 +139,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
+    warnings_logger (0.1.0)
 
 PLATFORMS
   ruby
@@ -157,6 +158,7 @@ DEPENDENCIES
   snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
+  warnings_logger
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest"
 gem "test-unit"
+gem "warnings_logger"
 gem "sqlite3", "~> 1.3.6"
 gem "rails", "~> 5.0.0"
 

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -142,6 +142,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
+    warnings_logger (0.1.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -163,6 +164,7 @@ DEPENDENCIES
   snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
+  warnings_logger
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest"
 gem "test-unit"
+gem "warnings_logger"
 gem "sqlite3", "~> 1.3.6"
 gem "rails", "~> 5.1.0"
 

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -142,6 +142,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
+    warnings_logger (0.1.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -163,6 +164,7 @@ DEPENDENCIES
   snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
+  warnings_logger
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest"
 gem "test-unit"
+gem "warnings_logger"
 gem "sqlite3", "~> 1.3.6"
 gem "rails", "~> 5.2.0"
 

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -150,6 +150,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
+    warnings_logger (0.1.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -171,6 +172,7 @@ DEPENDENCIES
   snowglobe (>= 0.3.0)
   sqlite3 (~> 1.3.6)
   test-unit
+  warnings_logger
 
 BUNDLED WITH
    1.17.3

--- a/lib/shoulda/context/context.rb
+++ b/lib/shoulda/context/context.rb
@@ -115,7 +115,12 @@ module Shoulda
 
         test_methods[test_unit_class][test_name.to_s] = true
         file, line_no = should[:block].source_location
-        context = self
+
+        # Ruby doesn't know that we are referring to this variable inside of the
+        # eval, so it will emit a warning that it's "assigned but unused".
+        # However, making a double assignment places `context` on the right hand
+        # side of the assignment, thereby putting it into use.
+        context = context = self
 
         test_unit_class.class_eval <<-end_eval, file, line_no
           define_method test_name do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ Tests::CurrentBundle.instance.assert_appraisal!
 
 #---
 
+require "pry-byebug"
+require "warnings_logger"
+
 TEST_FRAMEWORK = ENV.fetch("TEST_FRAMEWORK", "minitest")
 
 if TEST_FRAMEWORK == "test_unit"
@@ -13,8 +16,6 @@ else
   require "minitest/autorun"
   require "mocha/minitest"
 end
-
-require "pry-byebug"
 
 PROJECT_DIR = File.expand_path("../..", __FILE__)
 PARENT_TEST_CASE =
@@ -30,6 +31,13 @@ ASSERTION_CLASS =
     Minitest::Assertion
   end
 
+WarningsLogger::Spy.call(
+  project_name: "shoulda-context",
+  project_directory: Pathname.new("../..").expand_path(__FILE__)
+)
+
+require_relative "support/rails_application_with_shoulda_context"
+
 require_relative "../lib/shoulda/context"
 
 Shoulda.autoload_macros(
@@ -37,4 +45,4 @@ Shoulda.autoload_macros(
   File.join("vendor", "{plugins,gems}", "*")
 )
 
-require_relative "support/rails_application_with_shoulda_context"
+$VERBOSE = true


### PR DESCRIPTION
In converting a `should` within a `context` into a Minitest test (i.e.
method), we have to make use of `class_eval`. Inside of this eval we
refer to the Context object that we're inside of, which means we have to
set a variable outside of the eval. Unfortunately Ruby can't see into
the eval so it thinks that variable has gone unused and emits a warning.
The only real way to fix this is to make use of the variable somehow.
Double assigning the variable seems to do the trick.

Hat tip: @brandur, @pyrmont 