### PR TITLE
lib/context: fix Ruby 2.7 warning

### DIFF
--- a/lib/shoulda/context/context.rb
+++ b/lib/shoulda/context/context.rb
@@ -209,7 +209,6 @@ module Shoulda
         test_unit_class.send(method, *args, &blk)
       end
       ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
-
     end
 
     class DuplicateTestError < RuntimeError; end

--- a/lib/shoulda/context/context.rb
+++ b/lib/shoulda/context/context.rb
@@ -208,6 +208,8 @@ module Shoulda
       def method_missing(method, *args, &blk)
         test_unit_class.send(method, *args, &blk)
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
+
     end
 
     class DuplicateTestError < RuntimeError; end

--- a/test/shoulda/should_test.rb
+++ b/test/shoulda/should_test.rb
@@ -192,6 +192,18 @@ class ShouldTest < PARENT_TEST_CASE
     end
   end
 
+  def self.this_is_missing(foo, k: 1)
+  end
+
+  def test_should_pass_on_missing_method
+    context = Shoulda::Context::Context.new("context name", self.class) do; end
+
+    assert_nothing_raised do
+      h = { k: 42 }
+      context.this_is_missing(h)
+    end
+  end
+
   # Should statements
 
   def test_should_have_should_hashes_when_given_should_statements

--- a/test/shoulda/should_test.rb
+++ b/test/shoulda/should_test.rb
@@ -192,14 +192,13 @@ class ShouldTest < PARENT_TEST_CASE
     end
   end
 
-  def self.this_is_missing(foo, k: 1)
-  end
+  def self.this_is_missing(foo, bar: 1) end
 
   def test_should_pass_on_missing_method
-    context = Shoulda::Context::Context.new("context name", self.class) do; end
+    context = Shoulda::Context::Context.new("context name", self.class) {}
 
     assert_nothing_raised do
-      h = { k: 42 }
+      h = { bar: 42 }
       context.this_is_missing(h)
     end
   end


### PR DESCRIPTION
This fixes the warning for:

```
/vendor/gems/ruby/2.7.0/gems/shoulda-context-2.0.0/lib/shoulda/context/context.rb:209: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```