### PR TITLE
Bump warnings_logger to 0.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       power_assert
     thor (1.0.1)
     unicode-display_width (1.6.1)
-    warnings_logger (0.1.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This fixes warnings_logger so that it is actually functional under Minitest. (The code that does this is [here](https://github.com/mcmire/warnings_logger/commit/23281fbd3fefb5a5792229e3431207b2d1bee9c4#diff-2dcffe31d0377e2f04079ffb1a8f9e74R67-R73).)

---

Related to #64. 