### PR TITLE
Use File.exist?

### DIFF
--- a/exe/convert_to_should_syntax
+++ b/exe/convert_to_should_syntax
@@ -31,7 +31,7 @@ usage("Temp directory '#{TMP}' is not valid. Set TMPDIR environment variable to 
 
 file = ARGV.shift
 tmpfile = File.join(TMP, File.basename(file))
-usage("File '#{file}' doesn't exist") unless File.exists?(file)
+usage("File '#{file}' doesn't exist") unless File.exist?(file)
 
 FileUtils.cp(file, tmpfile)
 contents = File.read(tmpfile)


### PR DESCRIPTION
`File.exists?` was deprecated while ago and removed in Ruby 3.2.

https://bugs.ruby-lang.org/issues/17391
https://github.com/ruby/ruby/pull/5352