### PR TITLE
Match supported Ruby versions with `shoulda-matchers`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
 install: "bundle install --jobs=3 --retry=3"
 script: "bundle exec rake"
 rvm:
-  - 2.4.9
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
+  - 3.2.0
+  - 3.1.3
+  - 3.0.5
+  - 2.7.7
+  - 2.6.10
 env:
   - TEST_FRAMEWORK=minitest
   - TEST_FRAMEWORK=test_unit


### PR DESCRIPTION
I want to make sure the tests I'll be writing for https://github.com/thoughtbot/shoulda-context/pull/71 pass on appropriate Ruby versions.

I got the list from here https://github.com/thoughtbot/shoulda-matchers/blob/8fc832d52c36ac24d2c2d283c8d3665106f0e90f/.github/workflows/ci.yml#L29