### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -191,18 +191,7 @@ Shoulda Context is copyright © Tammer Saleh and [thoughtbot,
 inc][thoughtbot-website]. It is free and opensource software and may be
 redistributed under the terms specified in the [LICENSE](LICENSE) file.
 
-[thoughtbot-website]: https://thoughtbot.com
+[thoughtbot-website]: https://thoughtbot.com?utm_source=github
 
-## About thoughtbot
-
-![thoughtbot][thoughtbot-logo]
-
-[thoughtbot-logo]: https://thoughtbot.com/brand_assets/93:44.svg
-
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We are passionate about open source software. See [our other
-projects][community]. We are [available for hire][hire].
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com?utm_source=github
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.